### PR TITLE
docs: add v3.76.12 release notes (ACP v4.0-4.3, security patch)

### DIFF
--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -14,11 +14,29 @@ The following table shows the compatibility and support matrix between the Alaud
 
 | Alauda Build of Nexus Operator Version | Nexus Version |  ACP Version |
 | --------------------------------- | --------------- | --------------- |
+| v3.76.12                           | v3.76.0         | v4.0,v4.1,v4.2,v4.3 |
 | v3.76.11                           | v3.76.0         | v4.0,v4.1,v4.2,v4.3 |
 | v3.76.10                           | v3.76.0         | v4.0,v4.1,v4.2 |
 | v3.76.9                           | v3.76.0         | v4.0,v4.1,v4.2 |
 | v3.76.8                           | v3.76.0         | v4.0,v4.1 |
 | v3.76.7                           | v3.76.0         | v4.0,v4.1 |
+
+
+## v3.76.12
+
+### Features and Enhancements
+
+**Security Updates:** This release includes important security patches that address 61 CVEs across the operator and its bundled dependencies (including OpenSSL, golang.org/x/crypto/ssh, containerd, oras-go, and jackson-databind), and hardens the operator's ServiceAccount token mounting and RBAC permissions. See Security Errata `ASA-2026:00260` for details.
+
+### Fixed Issues
+
+
+{/* release-notes-for-bugs?template=fixed&project=DEVOPS&version=v3.76.12 */}
+
+
+### Known Issues
+
+{/* release-notes-for-bugs?template=unfixed&project=DEVOPS&version=v3.76.12 */}
 
 
 ## v3.76.11


### PR DESCRIPTION
Adds the **v3.76.12** release notes for Alauda Build of Nexus.

## Changes
- New `## v3.76.12` section — security patch release addressing **61 CVEs** across the operator + bundled dependencies (OpenSSL, golang.org/x/crypto/ssh, containerd, oras-go, jackson-databind, …) plus operator ServiceAccount-token / RBAC hardening. References Security Errata `ASA-2026:00260`.
- New **v3.76.12** row in the Compatibility & support matrix (ACP `v4.0,v4.1,v4.2,v4.3`).

## Context
- Jira: DEVOPS-44356
- Operator tag: `v3.76.12` (AlaudaDevops/nexus-ce-operator)
- Errata: https://cloud.alauda.io/errata/ASA-2026:00260

🤖 Generated with [Claude Code](https://claude.com/claude-code)